### PR TITLE
added some Sprint Planning questions

### DIFF
--- a/scrumchecklist.md
+++ b/scrumchecklist.md
@@ -29,6 +29,16 @@
 ####Respect
 - Do your Scrum team members respect each other to be capable, independent people?
 ###Events
+####Sprint Planning
+- Does the entire Scrum Team collaborate to plan the work of the upcoming Sprint?
+- Do the attendants understand the purpose of Sprint Planning?
+- Does the event consistently conclude within it's time box?
+- Are the following questions answered:
+    - What can be delivered in the Increment resulting from the upcoming Sprint?
+        - Does the Product Owner consistently share the business objectives for a Sprint?
+        - Is the Development Team allowed to choose the forecasted work?
+        - Does the Scrum Team collectively form a Sprint Goal based on the forecasted PBI's?
+    - How will the work needed to deliver the Increment be achieved?
 ###Roles
 ###Artifacts
 ##Recommended


### PR DESCRIPTION
Right now, the questions come almost directly from Scrum Guide. In the future, I imagine we may way to hone and whittle them down into terse bullets that don't make the user feel they could simply read the Scrum guide instead. Of course, we must do this without diverging from the spirit o the guide or sacrifice clarity and consistency of terminology.
